### PR TITLE
Initialize Next.js skeleton with Tailwind

### DIFF
--- a/nombre-proyecto/components/Layout.tsx
+++ b/nombre-proyecto/components/Layout.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+}
+
+export default function Layout({ children }: Props) {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <header className="bg-primary text-white p-4">
+        <nav className="container mx-auto flex space-x-4">
+          <Link href="/" className="hover:underline">Inicio</Link>
+          <Link href="/about" className="hover:underline">Acerca</Link>
+        </nav>
+      </header>
+      <main className="flex-1 container mx-auto p-4">{children}</main>
+      <footer className="bg-secondary text-white p-4 text-center">
+        &copy; {new Date().getFullYear()} Nombre Proyecto
+      </footer>
+    </div>
+  )
+}

--- a/nombre-proyecto/next-env.d.ts
+++ b/nombre-proyecto/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/nombre-proyecto/next.config.js
+++ b/nombre-proyecto/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/nombre-proyecto/package.json
+++ b/nombre-proyecto/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "nombre-proyecto",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "framer-motion": "^10.12.16"
+  },
+  "devDependencies": {
+    "typescript": "5.4.0",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16"
+  }
+}

--- a/nombre-proyecto/pages/_app.tsx
+++ b/nombre-proyecto/pages/_app.tsx
@@ -1,0 +1,11 @@
+import '../styles/globals.css'
+import type { AppProps } from 'next/app'
+import Layout from '../components/Layout'
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  )
+}

--- a/nombre-proyecto/pages/about.tsx
+++ b/nombre-proyecto/pages/about.tsx
@@ -1,0 +1,8 @@
+export default function About() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">Acerca de</h1>
+      <p className="mt-4">Información sobre el proyecto.</p>
+    </div>
+  )
+}

--- a/nombre-proyecto/pages/api/hello.ts
+++ b/nombre-proyecto/pages/api/hello.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  res.status(200).json({ name: 'John Doe' })
+}

--- a/nombre-proyecto/pages/index.tsx
+++ b/nombre-proyecto/pages/index.tsx
@@ -1,0 +1,10 @@
+import { motion } from 'framer-motion'
+
+export default function Home() {
+  return (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.5 }}>
+      <h1 className="text-2xl font-bold">Bienvenido a Nombre Proyecto</h1>
+      <p className="mt-4">Esta es la página inicial.</p>
+    </motion.div>
+  )
+}

--- a/nombre-proyecto/postcss.config.js
+++ b/nombre-proyecto/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/nombre-proyecto/styles/globals.css
+++ b/nombre-proyecto/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply font-sans;
+}

--- a/nombre-proyecto/tailwind.config.js
+++ b/nombre-proyecto/tailwind.config.js
@@ -1,0 +1,19 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#1e40af',
+        secondary: '#1d4ed8'
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif']
+      }
+    }
+  },
+  plugins: [],
+}

--- a/nombre-proyecto/tsconfig.json
+++ b/nombre-proyecto/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js project in `nombre-proyecto`
- add Tailwind CSS configuration
- create global layout and example pages
- include Framer Motion demo

## Testing
- `npx create-next-app@latest proyecto-fail --typescript` *(fails: hangs without network)*